### PR TITLE
CSV export

### DIFF
--- a/src/actions/tournaments.ts
+++ b/src/actions/tournaments.ts
@@ -2,6 +2,7 @@
 
 import { db } from "@/db";
 import { tournament } from "@/db/schema";
+import { eq } from "drizzle-orm";
 
 export async function getAllTournaments() {
     const tournaments = await db
@@ -9,3 +10,11 @@ export async function getAllTournaments() {
         .from(tournament);
     return tournaments;
 };
+
+export async function getTournamentById(id: number) {
+    const result = await db
+        .select()
+        .from(tournament)
+        .where(eq(tournament.id, id));
+    return result[0] ?? null;
+}

--- a/src/app/[tournamentid]/stats/page.tsx
+++ b/src/app/[tournamentid]/stats/page.tsx
@@ -1,6 +1,8 @@
 "use server";
 import { getPlayersForTournamentId } from "@/actions/players";
 import { getTeamsForTournamentSorted } from "@/actions/teams";
+import { getTournamentById } from "@/actions/tournaments";
+import ExportCSVButton from "@/components/ExportCSVButton";
 
 export default async function Home(params: {
   params: { tournamentid: number };
@@ -10,6 +12,7 @@ export default async function Home(params: {
   const teamsOrdered = await getTeamsForTournamentSorted(
     params.params.tournamentid
   );
+  const tournament = await getTournamentById(params.params.tournamentid);
 
   const playersSortedByBlowjobs = playersBJ.sort(
     (a, b) => (Number(b.blowjobs) ?? 0) - (Number(a.blowjobs) ?? 0)
@@ -18,9 +21,12 @@ export default async function Home(params: {
     (a, b) => (Number(b.score) ?? 0) - (Number(a.score) ?? 0)
   );
 
+  const tournamentName = tournament?.name ?? "tournament";
+
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
+        <div className="flex justify-end w-full"></div>
         <div className="flex justify-between w-full text-center gap-8 row-start-3">
           <div className="rounded-lg text-center shadow-md p-6">
             <h2 className="text-xl font-bold mb-4">Celkové skóre</h2>
@@ -117,6 +123,12 @@ export default async function Home(params: {
             </table>
           </div>
         </div>
+        <ExportCSVButton
+          teams={teamsOrdered}
+          playersByScore={playersSortedByScore}
+          playersByBlowjobs={playersSortedByBlowjobs}
+          tournamentName={tournamentName}
+        />
       </main>
     </div>
   );

--- a/src/app/[tournamentid]/stats/page.tsx
+++ b/src/app/[tournamentid]/stats/page.tsx
@@ -26,7 +26,6 @@ export default async function Home(params: {
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
-        <div className="flex justify-end w-full"></div>
         <div className="flex justify-between w-full text-center gap-8 row-start-3">
           <div className="rounded-lg text-center shadow-md p-6">
             <h2 className="text-xl font-bold mb-4">Celkové skóre</h2>

--- a/src/components/ExportCSVButton.tsx
+++ b/src/components/ExportCSVButton.tsx
@@ -11,8 +11,9 @@ interface Props {
 }
 
 function escapeCSV(value: string | number | null | undefined): string {
-  const str = String(value ?? "").replace(/\n/g, " ");
-  if (str.includes(",") || str.includes('"')) {
+  const str = String(value ?? "");
+
+  if (/[,"\n\r]/.test(str)) {
     return `"${str.replace(/"/g, '""')}"`;
   }
   return str;

--- a/src/components/ExportCSVButton.tsx
+++ b/src/components/ExportCSVButton.tsx
@@ -1,23 +1,21 @@
 "use client";
 
-interface Team {
-  id: number;
-  name: string;
-  score: number;
-}
-
-interface Player {
-  id: number;
-  name: string | null;
-  score: string | null;
-  blowjobs: string | null;
-}
+import { Player } from "@/types/player";
+import { Team } from "@/types/team";
 
 interface Props {
   teams: Team[];
   playersByScore: Player[];
   playersByBlowjobs: Player[];
   tournamentName: string;
+}
+
+function escapeCSV(value: string | number | null | undefined): string {
+  const str = String(value ?? "");
+  if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
 }
 
 function ExportCSVButton({
@@ -33,7 +31,7 @@ function ExportCSVButton({
     lines.push("Team Rankings");
     lines.push("Rank,Team,Score");
     teams.forEach((team, index) => {
-      lines.push(`${index + 1},${team.name ?? ""},${team.score ?? 0}`);
+      lines.push(`${index + 1},${escapeCSV(team.name)},${escapeCSV(team.score)}`);
     });
 
     lines.push("");
@@ -42,7 +40,7 @@ function ExportCSVButton({
     lines.push("Top Scorers");
     lines.push("Rank,Player,Score");
     playersByScore.forEach((player, index) => {
-      lines.push(`${index + 1},${player.name ?? ""},${player.score ?? 0}`);
+      lines.push(`${index + 1},${escapeCSV(player.name)},${escapeCSV(player.score)}`);
     });
 
     lines.push("");
@@ -51,7 +49,7 @@ function ExportCSVButton({
     lines.push("BlowJob King");
     lines.push("Rank,Player,Count");
     playersByBlowjobs.forEach((player, index) => {
-      lines.push(`${index + 1},${player.name ?? ""},${player.blowjobs ?? 0}`);
+      lines.push(`${index + 1},${escapeCSV(player.name)},${escapeCSV(player.blowjobs)}`);
     });
 
     const csvContent = lines.join("\n");

--- a/src/components/ExportCSVButton.tsx
+++ b/src/components/ExportCSVButton.tsx
@@ -11,8 +11,8 @@ interface Props {
 }
 
 function escapeCSV(value: string | number | null | undefined): string {
-  const str = String(value ?? "");
-  if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+  const str = String(value ?? "").replace(/\n/g, " ");
+  if (str.includes(",") || str.includes('"')) {
     return `"${str.replace(/"/g, '""')}"`;
   }
   return str;

--- a/src/components/ExportCSVButton.tsx
+++ b/src/components/ExportCSVButton.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+interface Team {
+  id: number;
+  name: string;
+  score: number;
+}
+
+interface Player {
+  id: number;
+  name: string | null;
+  score: string | null;
+  blowjobs: string | null;
+}
+
+interface Props {
+  teams: Team[];
+  playersByScore: Player[];
+  playersByBlowjobs: Player[];
+  tournamentName: string;
+}
+
+function ExportCSVButton({
+  teams,
+  playersByScore,
+  playersByBlowjobs,
+  tournamentName,
+}: Props) {
+  const handleExport = () => {
+    const lines: string[] = [];
+
+    // Team Rankings
+    lines.push("Team Rankings");
+    lines.push("Rank,Team,Score");
+    teams.forEach((team, index) => {
+      lines.push(`${index + 1},${team.name ?? ""},${team.score ?? 0}`);
+    });
+
+    lines.push("");
+
+    // Top Scorers
+    lines.push("Top Scorers");
+    lines.push("Rank,Player,Score");
+    playersByScore.forEach((player, index) => {
+      lines.push(`${index + 1},${player.name ?? ""},${player.score ?? 0}`);
+    });
+
+    lines.push("");
+
+    // BlowJob King
+    lines.push("BlowJob King");
+    lines.push("Rank,Player,Count");
+    playersByBlowjobs.forEach((player, index) => {
+      lines.push(`${index + 1},${player.name ?? ""},${player.blowjobs ?? 0}`);
+    });
+
+    const csvContent = lines.join("\n");
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+
+    const sanitizedName = tournamentName.replace(/\s+/g, "-");
+    const filename = `${sanitizedName}-stats.csv`;
+
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    link.click();
+
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <button onClick={handleExport} className="btn btn-primary">
+      Export CSV
+    </button>
+  );
+}
+
+export default ExportCSVButton;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI feature that adds a new read-only DB query and client-side file generation; main risks are minor CSV formatting/filename edge cases.
> 
> **Overview**
> Adds a CSV export capability to the tournament stats page, generating a downloadable `*-stats.csv` containing team rankings, top scorers, and “BlowJob King” tables.
> 
> Introduces a new client component `ExportCSVButton` that builds/escapes CSV content in-browser and uses the tournament name for the filename, and adds a new `getTournamentById` server action (Drizzle `where(eq(...))`) to fetch that name for the export.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bdcbc6a40ba88e1fa7ab02d5505ef9372581c96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->